### PR TITLE
BAH-2220 | Siva Reddy | Fixing NPE

### DIFF
--- a/api/src/main/java/org/bahmni/module/bahmni/ie/apps/service/impl/BahmniFormTranslationServiceImpl.java
+++ b/api/src/main/java/org/bahmni/module/bahmni/ie/apps/service/impl/BahmniFormTranslationServiceImpl.java
@@ -344,7 +344,7 @@ public class BahmniFormTranslationServiceImpl extends BaseOpenmrsService impleme
 		List<Concept> conceptsByName = conceptService.getConceptsByName(conceptName);
 		for (Concept concept : conceptsByName) {
 			ConceptName name = concept.getName();
-			if (concept.getName().getConceptNameType().equals(ConceptNameType.FULLY_SPECIFIED) && name.getName()
+			if (ConceptNameType.FULLY_SPECIFIED.equals(concept.getName().getConceptNameType()) && name.getName()
 					.equalsIgnoreCase(conceptName)) {
 				return concept;
 			}


### PR DESCRIPTION
JIRA - [https://bahmni.atlassian.net/browse/BAH-2220](https://bahmni.atlassian.net/browse/BAH-2220)

- with CIEL Dictionary, lot of synonyms were imported. 

Null Pointer Exception is throwing when the concept Fully Specified Name matches with one of the synonyms since concept_name_type for the synonym is null.


